### PR TITLE
s/7.0/7.0.22/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   directories:
     - vendor
 php:
-  - 7.0
+  - 7.0.22
   - 7.1
 install:
   - composer --no-interaction install


### PR DESCRIPTION
Travis uses 7.0.7 by default which is rejected by dependencies.

(We will not need to tag this as a release since there's no code changes)