### PR TITLE
Add unwrapOr function to Ok/Err classes

### DIFF
--- a/spec/err.spec.php
+++ b/spec/err.spec.php
@@ -11,6 +11,14 @@ describe(\Dxw\Result\Err::class, function () {
         });
     });
 
+    describe('->unwrapOr()', function () {
+        it('should return the value given', function () {
+            $result = new \Dxw\Result\Err('foo');
+
+            expect($result->unwrapOr('default'))->to->equal('default');
+        });
+    });
+
     describe('->getErr()', function () {
         it('should report the error given', function () {
             $result = new \Dxw\Result\Err('meow');

--- a/spec/ok.spec.php
+++ b/spec/ok.spec.php
@@ -9,6 +9,14 @@ describe(\Dxw\Result\Ok::class, function () {
         });
     });
 
+    describe('->unwarpOr()', function () {
+        it('should allow extracting values', function () {
+            $result = new \Dxw\Result\Ok('cat');
+
+            expect($result->unwrapOr('default'))->to->equal('cat');
+        });
+    });
+
     describe('->isErr()', function () {
         it('should always be false', function () {
             $result = new \Dxw\Result\Ok('cat');

--- a/src/Err.php
+++ b/src/Err.php
@@ -17,6 +17,11 @@ class Err extends Result
         throw new \RuntimeException("Can't unwrap error");
     }
 
+    public function unwrapOr($default)
+    {
+        return $default;
+    }
+
     public function getErr(): string
     {
         return $this->message;

--- a/src/Ok.php
+++ b/src/Ok.php
@@ -21,6 +21,11 @@ class Ok extends Result
         return $this->value;
     }
 
+    public function unwrapOr($default)
+    {
+        return $this->unwrap();
+    }
+
     public function isErr(): bool
     {
         return false;

--- a/src/Result.php
+++ b/src/Result.php
@@ -8,6 +8,12 @@ abstract class Result
     /** @return T1 */
     abstract public function unwrap();
 
+    /**
+    @param T1 $default
+    @return T1
+    */
+    abstract public function unwrapOr($default);
+
     abstract public function isErr(): bool;
     abstract public function getErr(): string;
     abstract public function wrap(string $message): \Dxw\Result\Result;


### PR DESCRIPTION
Closes #7
---

`unwrapOr` is a way to get the value of a computation that might fail or be missing. If the computation succeeds or has a value, it returns that value. If the computation fails or has no value, it returns a default value that you provide.