### PR TITLE
Add PHP 8.1 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-versions: ['7.4', '8.2']
+        php-versions: ['7.4', '8.1', '8.2']
     steps:
       - uses: actions/checkout@v3
       - name: Setup PHP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Support for PHP 8.1
+
 ## [1.0.5] - 2023-07-17
 ### Added
 - Support for PHP 8.2

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
         "dxw/php-cs-fixer-config": "^2.1"
     },
     "require": {
-        "php": "^7.4||^8.2"
+        "php": "^7.4||^8.1"
     }
 }


### PR DESCRIPTION
Another of our libraries (dxw/Result) uses this package, and has had PHP 8.1 support requested by a third party. It's not in EOL yet, so adding it here should allow us to use 8.1 is Result as well.